### PR TITLE
feat: add jmap to simplify json unmarshal method

### DIFF
--- a/json.go
+++ b/json.go
@@ -1,0 +1,49 @@
+package g
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+type JMap map[string]any
+
+func (j JMap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j)
+}
+
+func (j *JMap) UnmarshalJSON(bts []byte) error {
+
+	tmpVal := make(map[string]interface{})
+
+	d := json.NewDecoder(bytes.NewBuffer(bts))
+	d.UseNumber()
+
+	if err := d.Decode(&tmpVal); err != nil {
+		return err
+	}
+
+	for k, v := range tmpVal {
+
+		parsedValue := v
+		var err error
+
+		switch tv := v.(type) {
+		case json.Number:
+			if strings.Contains(string(tv), ".") {
+				if parsedValue, err = tv.Float64(); err != nil {
+					return err
+				}
+			} else {
+				if parsedValue, err = tv.Int64(); err != nil {
+					return err
+				}
+			}
+		default:
+		}
+
+		(*j)[k] = parsedValue
+	}
+
+	return nil
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,55 @@
+package g
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJMap(t *testing.T) {
+
+	is := assert.New(t)
+
+	// 测试json对于各种数据解析的能力
+
+	{
+		val := `{"a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7,"h":8}`
+
+		data := make(map[string]interface{})
+
+		err := json.Unmarshal([]byte(val), Ptr(JMap(data)))
+
+		is.Nil(err)
+		is.Equal(8, len(data))
+		is.Equal(int64(1), data["a"])
+		is.Equal(int64(2), data["b"])
+		is.Equal(int64(3), data["c"])
+	}
+
+	// 测试对于其他类型的解析能力
+	{
+		val := `{"name": "golang", "age": 10, "score": 99.9, "is_ok": true, "is_not_ok": false, "nil": null}`
+		data := make(map[string]interface{})
+		err := json.Unmarshal([]byte(val), Ptr(JMap(data)))
+		is.Nil(err)
+		is.Equal(6, len(data))
+		is.Equal("golang", data["name"])
+		is.Equal(int64(10), data["age"])
+		is.Equal(99.9, data["score"])
+		is.Equal(true, data["is_ok"])
+		is.Equal(false, data["is_not_ok"])
+		is.Equal(nil, data["nil"])
+	}
+
+	// 测试bigint的精度能力
+	{
+		val := `{"a": 9223372036854775807, "b": 1.2e8}`
+		data := make(map[string]interface{})
+		err := json.Unmarshal([]byte(val), Ptr(JMap(data)))
+		is.Nil(err)
+		is.Equal(2, len(data))
+		is.Equal(int64(9223372036854775807), data["a"])
+		is.Equal(1.2e8, data["b"])
+	}
+}


### PR DESCRIPTION
Add a simpler method to solve precision losing problem in json unmarshal method.

Here is simple example:

```go
    val := `{"a": 9223372036854775807, "b": 1.2e8}`
    data := make(map[string]interface{})
    err := json.Unmarshal([]byte(val), &data))

   log.Println(data["a]) // => 9223372036854776000 (float64)
```

Just replace one line code as follows:

original:
```go
    err := json.Unmarshal([]byte(val), &data))
    // => 9223372036854776000 (float64)
```
to:
```go
    err := json.Unmarshal([]byte(val), Ptr(JMap(data)))
    // => 9223372036854775807 (int64)
```

whole code as follows:
```go

    val := `{"a": 9223372036854775807, "b": 1.2e8}`
    data := make(map[string]interface{})
    err := json.Unmarshal([]byte(val), Ptr(JMap(data)))

   log.Println(data["a]) // => 9223372036854776000 (float64)

```
